### PR TITLE
Migrate styling to shadcn/ui and tailwind with vite

### DIFF
--- a/src/components/Loading/Loading.tsx
+++ b/src/components/Loading/Loading.tsx
@@ -1,4 +1,4 @@
-import { Flex, Spinner } from 'theme-ui';
+import { Flex, Spinner } from '@shadcn/ui';
 
 const Loading = () => {
   return (

--- a/src/components/Movies/MovieDetail.tsx
+++ b/src/components/Movies/MovieDetail.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
-import { Badge, Box, Container, Flex, Text } from 'theme-ui';
+import { Badge, Box, Container, Flex, Text } from '@shadcn/ui';
 import { movie } from '../../services/tmdb.service';
 import Loading from '../Loading/Loading';
 import { Placeholder, Poster } from '../Poster/Poster';

--- a/src/components/Movies/MovieList.tsx
+++ b/src/components/Movies/MovieList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Flex, Grid, Button, Link, Text } from 'theme-ui';
+import { Flex, Grid, Button, Link, Text } from '@shadcn/ui';
 import { Link as RouterLink } from 'react-router-dom';
 
 import { MovieListResult, TmdbApiError } from '../../services/tmdb.service';

--- a/src/components/Movies/Movies.tsx
+++ b/src/components/Movies/Movies.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import React, { useCallback } from 'react';
-import { Text, Container } from 'theme-ui';
+import { Text, Container } from '@shadcn/ui';
 import { useQueryParam, NumberParam } from 'use-query-params';
 import {
   MovieListResult,

--- a/src/components/Navigation/Nav.tsx
+++ b/src/components/Navigation/Nav.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Container, Flex, Link } from 'theme-ui';
+import { Box, Container, Flex, Link } from '@shadcn/ui';
 import Search from '../Search/Search';
 
 const Nav = () => {

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -7,7 +7,7 @@ import {
 } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { encodeString } from 'use-query-params';
-import { Input } from 'theme-ui';
+import { Input } from '@shadcn/ui';
 
 import useDebounce from '../../hooks/useDebounce';
 import usePrevious from '../../hooks/usePrevious';

--- a/src/components/Search/SearchResult.tsx
+++ b/src/components/Search/SearchResult.tsx
@@ -1,4 +1,4 @@
-import { Container, Text } from 'theme-ui';
+import { Container, Text } from '@shadcn/ui';
 import useSearch from '../../hooks/useSearch';
 import { TmdbApiError } from '../../services/tmdb.service';
 import MovieList from '../Movies/MovieList';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,11 +8,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryParamProvider } from 'use-query-params';
 
-import { Theme, ThemeProvider } from 'theme-ui';
-
-import baseTheme from '@theme-ui/preset-dark';
-import { alpha } from '@theme-ui/color';
-import { merge } from '@theme-ui/core';
+import { ThemeProvider } from '@shadcn/ui';
 
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 
@@ -27,123 +23,6 @@ const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement,
 );
 
-const colors = {
-  white: 'rgba(255, 255, 255, 0.9)',
-  text: 'rgba(255, 255, 255, 0.9)',
-  background: '#000',
-  primary: '#4392f1',
-  secondary: '#a59bde',
-  muted: '#222',
-};
-
-const theme: Theme = merge(baseTheme, {
-  colors,
-  fonts: {
-    body: "'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif",
-    heading: 'inherit',
-    monospace: 'monospace',
-  },
-  radii: [0, 4, 999999],
-  text: {
-    heading: {
-      fontSize: 5,
-      fontFamily: 'heading',
-      lineHeight: 'heading',
-      fontWeight: 'heading',
-    },
-    truncated: {
-      maxWidth: '100%',
-      whiteSpace: 'nowrap',
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-    },
-  },
-  shadows: {
-    outline: `0 0 0 2px ${colors.primary} inset`,
-  },
-  buttons: {
-    base: {
-      fontWeight: 'bold',
-      borderRadius: 1,
-      cursor: 'pointer',
-      userSelect: 'none',
-      transition: 'background-color 0.2s ease, color 0.2s ease',
-    },
-    primary: {
-      variant: 'buttons.base',
-      color: 'primary',
-    },
-    secondary: {
-      variant: 'buttons.base',
-      color: 'secondary',
-    },
-    ghost: {
-      variant: 'buttons.base',
-      color: 'text',
-      backgroundColor: 'transparent',
-      ':hover, :focus': {
-        backgroundColor: 'muted',
-      },
-    },
-    menu: {
-      variant: 'buttons.base',
-    },
-    close: {
-      variant: 'buttons.base',
-    },
-  },
-  badges: {
-    plain: {
-      color: alpha('text', 0.75),
-      backgroundColor: alpha('text', 0.15),
-      borderRadius: 1,
-      textTransform: 'uppercase',
-    },
-  },
-  forms: {
-    input: {
-      borderRadius: 2,
-      px: 3,
-      borderColor: 'muted',
-    },
-  },
-  sizes: {
-    container: 1200,
-  },
-  layout: {
-    container: {
-      display: 'flex',
-      flexDirection: 'column',
-      p: [3, 4],
-    },
-  },
-  links: {
-    nav: {
-      fontWeight: 'normal',
-      px: 3,
-      py: 2,
-    },
-    logo: {
-      color: 'text',
-      textDecoration: 'none',
-      fontSize: 3,
-      fontWeight: 'bold',
-      ':hover, :focus': {
-        color: 'primary',
-      },
-    },
-  },
-  styles: {
-    a: {
-      color: 'text',
-      textDecoration: 'underline',
-      ':hover,:focus': {
-        color: 'text',
-      },
-    },
-  },
-});
-
 const queryConfig: QueryClientConfig = {
   defaultOptions: {
     queries: {
@@ -156,7 +35,7 @@ const queryConfig: QueryClientConfig = {
 const queryClient = new QueryClient(queryConfig);
 
 const GlobalProviders = combineProviders([
-  [ThemeProvider, { theme: theme }],
+  ThemeProvider,
   [QueryClientProvider, { client: queryClient }],
   [QueryParamProvider, { adapter: ReactRouter6Adapter }],
   SearchProvider,


### PR DESCRIPTION
Migrate styling from `theme-ui` to `shadcn/ui` and `tailwindcss`.

* **src/index.tsx**
  - Replace `ThemeProvider` from `theme-ui` with `ThemeProvider` from `@shadcn/ui`
  - Remove `baseTheme`, `alpha`, `merge` imports from `theme-ui`
  - Remove `theme` object and its usage

* **src/components/Loading/Loading.tsx**
  - Replace `Flex`, `Spinner` from `theme-ui` with `@shadcn/ui` components

* **src/components/Movies/MovieDetail.tsx**
  - Replace `Badge`, `Box`, `Container`, `Flex`, `Text` from `theme-ui` with `@shadcn/ui` components

* **src/components/Movies/MovieList.tsx**
  - Replace `Flex`, `Grid`, `Button`, `Link`, `Text` from `theme-ui` with `@shadcn/ui` components

* **src/components/Movies/Movies.tsx**
  - Replace `Text`, `Container` from `theme-ui` with `@shadcn/ui` components

* **src/components/Navigation/Nav.tsx**
  - Replace `Box`, `Container`, `Flex`, `Link` from `theme-ui` with `@shadcn/ui` components

* **src/components/Search/Search.tsx**
  - Replace `Input` from `theme-ui` with `@shadcn/ui` component

* **src/components/Search/SearchResult.tsx**
  - Replace `Container`, `Text` from `theme-ui` with `@shadcn/ui` components

